### PR TITLE
`Zend_Form_Element`: Ensure backward compatibility

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -601,7 +601,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * @param  string $key
      * @return void
      */
-    protected function _filterValue(&$value, $key)
+    protected function _filterValue(&$value, &$key)
     {
         foreach ($this->getFilters() as $filter) {
             $value = $filter->filter($value);
@@ -618,7 +618,9 @@ class Zend_Form_Element implements Zend_Validate_Interface
         $valueFiltered = $this->_value;
 
         if ($this->isArray() && is_array($valueFiltered)) {
-            array_walk_recursive($valueFiltered, [$this, '_filterValue']);
+            array_walk_recursive($valueFiltered, function (&$val, $key) {
+                $this->_filterValue($val, $key);
+            });
         } else {
             $this->_filterValue($valueFiltered, $valueFiltered);
         }


### PR DESCRIPTION
In `Director < v1.11.7`, the `__filterValue()` method of the `Boolean`,  `DataFilter` and `ExtensibleSet` classes defined argument `#2` ($key) as  a reference, as the base class `Zend_Form_Element` from the original     
`zendframework` had previously used this signature.

With https://github.com/Shardj/zf1-future/commit/5ae9f922ca97bd59a7f70e5c2efb10b360eae331#diff-4de0f6e712ea2a7c9a1bcd60f804afb239d82095cfa68e28e18e2946d2b4abc4R591 the param `$key` was changed to accept a value instead of a reference,  to ensure PHP 8.0 compatibility, because otherwise the `array_walk_recursive` closure in `Zend_Form_Element::getValue()` threw an error on PHP 8.0.                                               
                                                                         
This is documented here: https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.standard
"Any functions accepting callbacks that are not explicitly specified to  accept parameters by reference will now warn if a callback with reference parameters is used. Examples include `array_filter()` and `array_reduce()`. This was already the case for most, but not all, functions previously."                                                   
                                                                         
The change of param `$key` broke the `Director` module, which was later fixed with https://github.com/Icinga/icinga-php-thirdparty/pull/16 and https://github.com/Icinga/icinga-php-thirdparty/pull/20.             
                                                                         
Instead of applying the patches to our new replacement `Icinga/zf1` of `shardj/zf1-future`, the classes overwritting this method in `Director` has been adjusted accordingly with https://github.com/Icinga/icingaweb2-module-director/commit/e13d840ace1c0ab6b52ec6a60c8e469cea432899, which now breaks the backward compatibility.                             
                                                                         
The changes from the patches mentioned above are applied again.          
The `Director` module must be adjusted accordingly.